### PR TITLE
Fix: Hardcoded radio_module LoraMonitor

### DIFF
--- a/lib/cli_apps/lora_monitor.ex
+++ b/lib/cli_apps/lora_monitor.ex
@@ -16,8 +16,9 @@ defmodule CLIApps.LoraMonitor do
       }
 
     {:ok, periph_config} = HAL.get_peripheral_config("radio")
+    %{radio_module: radio_module} = periph_config
     lora_config = Map.merge(lora_config, periph_config)
-    {:ok, _lora} = :lora_sx126x.start(lora_config)
+    {:ok, _lora} = radio_module.start(lora_config)
 
     recv_loop()
   end


### PR DESCRIPTION
Support :lora_sx127x etc.

Could one-line it:
`{:ok, %{radio_module: radio_module} = periph_config} = HAL.get_peripheral_config("radio")`

but prefer two lines, your call..