### PR TITLE
meshtastic: advertise the platform hardware model

### DIFF
--- a/lib/hal.ex
+++ b/lib/hal.ex
@@ -373,6 +373,12 @@ defmodule HAL do
   defp has_peripheral?("t-pager", "gps"), do: true
   defp has_peripheral?(_, _), do: false
 
+  def hw_model, do: hw_model(@platform)
+
+  defp hw_model("t-deck"), do: 50
+  defp hw_model("t-pager"), do: 103
+  defp hw_model(_), do: 0
+
   def get_peripheral_config(periph) do
     get_peripheral_config(@platform, periph)
   end

--- a/lib/radio_launcher.ex
+++ b/lib/radio_launcher.ex
@@ -42,7 +42,7 @@ defmodule RadioLauncher do
       user_info: %{
         id: "!#{node_id_string}",
         macaddr: macaddr,
-        hw_model: 50,
+        hw_model: HAL.hw_model(),
         role: role_atom(Map.get(mt_cfg, :role, :client)),
         long_name: long_name,
         short_name: short_name,


### PR DESCRIPTION
nitpick vanity, so correct hw_model shows up:
<img width="348" height="303" alt="Screenshot 2026-08-12 at 18 58 36" src="https://github.com/user-attachments/assets/07e0d34e-7b6b-4b67-8166-caeac7c7ddd7" />

RadioLauncher currently identifies every device as a T-Deck. Resolve the Meshtastic HardwareModel value through HAL so T-Deck reports 50, T-Lora Pager reports 103, and unsupported platforms use UNSET (0).

AMP:

The fix is correct:

- T-Deck → Meshtastic model 50
- T-Lora Pager → model 103
- Unsupported platforms → UNSET (0)
- Current t-pager builds previously advertised incorrectly as T-Deck

Validation:

- 298 tests passed
- Formatting and diff checks passed
- Branch is one commit ahead of main